### PR TITLE
Fix trigger timing and extend trigger length

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "avrlib"]
 	path = avrlib
 	url = https://github.com/pichenettes/avril.git
-[submodule "avrlibx"]
-	path = avrlibx
-	url = https://github.com/pichenettes/avrilx.git
 [submodule "avr_audio_bootloader"]
 	path = avr_audio_bootloader
 	url = https://github.com/pichenettes/avr-audio-bootloader.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "avrlib"]
 	path = avrlib
-	url = https://github.com/pichenettes/avril
+	url = https://github.com/pichenettes/avril.git
+[submodule "avrlibx"]
+	path = avrlibx
+	url = https://github.com/pichenettes/avrilx.git
+[submodule "avr_audio_bootloader"]
+	path = avr_audio_bootloader
+	url = https://github.com/pichenettes/avr-audio-bootloader.git

--- a/bootloader/bootloader.cc
+++ b/bootloader/bootloader.cc
@@ -1,4 +1,4 @@
-// Copyright 2013 Olivier Gillet.
+// Copyright 2013 Emilie Gillet.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/bootloader/makefile
+++ b/bootloader/makefile
@@ -1,4 +1,4 @@
-# Copyright 2011 Olivier Gillet.
+# Copyright 2011 Emilie Gillet.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-# Copyright 2012 Olivier Gillet.
+# Copyright 2012 Emilie Gillet.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/twigs.cc
+++ b/twigs.cc
@@ -229,6 +229,7 @@ void SystemInit() {
 
   // Hardware interface
   GateInputsInit();
+  ClockInit();
   ButtonsInit();
   GateOutputsInit();
   LedsInit();
@@ -238,8 +239,6 @@ void SystemInit() {
 
   TCCR1A = 0;
   TCCR1B = 5;
-
-  ClockInit();
 }
 
 // Read the value of the given gate input


### PR DESCRIPTION
Bugfix output trigger timing and improve output trigger length.

- Bugfix output trigger timing
  - How to reproduce
    In factor mode, input clock trigger signal.
  - Actual behavior
    Output trigger timing is unstable every about 8 seconds.
  - Expected behavior
    Output trigger timing is stable.

- Improve output trigger length
  Some another modules requires trigger length about 2.5 milliseconds,
  Current output trigger length is too short to recognize for the modules.
  So extend output trigger length to 2.56 milliseconds.

- Acknowledgements:
  Z_Hyper (reporter, tester)
